### PR TITLE
Get Rid of Unintended SideEffects on PreviewBanner component

### DIFF
--- a/packages/sveltekit-preview-mode/src/lib/components/PreviewBanner.svelte
+++ b/packages/sveltekit-preview-mode/src/lib/components/PreviewBanner.svelte
@@ -4,10 +4,11 @@
 
   let exit_link: string;
 
-  $: {
-    $page.url.searchParams.set($page.data.exitPreviewQueryParam, "true");
-    exit_link = $page.url.toString();
-  }
+	$: {
+		const url = new URL($page.url);
+		url.searchParams.set($page.data.exitPreviewQueryParam, 'true');
+		exit_link = url.toString();
+	}
 </script>
 
 {#if isPreview()}


### PR DESCRIPTION
## Problem

If you are using this component the page url will always be updated weather you are in preview mode or not. The page url will be update. This causes unintended sideffects if you have other components that rely on the `$page.url` data

## Fix

Update the exit_link to get url from copy not by editing the $page.url store.