### PR TITLE
Fix Cache Control Header in Handler

### DIFF
--- a/packages/sveltekit-preview-mode/src/lib/index.ts
+++ b/packages/sveltekit-preview-mode/src/lib/index.ts
@@ -39,7 +39,6 @@ export default function previewMode(options?: PreviewModeOptions): Handle {
   } satisfies PreviewModeOptions;
 
   return function ({ event, resolve }) {
-    event.setHeaders({ "Cache-Control": "no-store" });
     event.locals.exitPreviewQueryParam = o.exitPreviewQueryParam;
 
     const is_exit = event.url.searchParams.has(o.exitPreviewQueryParam);
@@ -64,6 +63,7 @@ export default function previewMode(options?: PreviewModeOptions): Handle {
 
     if (has_preview_cookie || secret_matches || isPreview()) {
       setPreview(true);
+      event.setHeaders({ "Cache-Control": "no-store" });
       event.locals.isPreview = true;
 
       if (secret_matches) {


### PR DESCRIPTION
## Problem
 
Currently the cache-control header is always applied even if the user is not in preview mode. This basically blocks you out of any custom cache control header in any of your load functions, as Sveltekit does not allow you to override or set this header twice.

## Solution

I think the solution is quite simple we should just only set the cache-control header to `no-store` if the app is in preview mode. This will allow regular responses to be cached whilst not caching the preview content.

## Additional Considerations

Perhaps additional documentation on how to handle caching in docs? It will probably need to be documented that you still need to check if you are in preview mode before setting any `cache-control`  header