### PR TITLE
[Major] Remove Shared State on the Server 

### DIFF
--- a/examples/contentful/src/lib/cms.ts
+++ b/examples/contentful/src/lib/cms.ts
@@ -6,13 +6,12 @@ import {
   CONTENTFUL_PREVIEW_ACCESS_TOKEN,
   CONTENTFUL_SPACE_ID,
 } from "$env/static/private";
-import { isPreview } from "sveltekit-preview-mode";
 import type { Post, PostAndMorePosts } from "schema";
 
-const client = () => {
+const client = (isPreview = false) => {
   return contentful.createClient({
-    accessToken: isPreview() ? CONTENTFUL_PREVIEW_ACCESS_TOKEN : CONTENTFUL_DELIVERY_ACCESS_TOKEN,
-    host: isPreview() ? "preview.contentful.com" : "cdn.contentful.com",
+    accessToken: isPreview ? CONTENTFUL_PREVIEW_ACCESS_TOKEN : CONTENTFUL_DELIVERY_ACCESS_TOKEN,
+    host: isPreview ? "preview.contentful.com" : "cdn.contentful.com",
     space: CONTENTFUL_SPACE_ID,
   });
 };
@@ -63,14 +62,17 @@ function model_post(item: contentful.Entry<BlogPost>): Post {
   };
 }
 
-export const get_post_and_more_posts = async (slug: string): Promise<PostAndMorePosts> => {
+export const get_post_and_more_posts = async (
+  slug: string,
+  isPreview = false,
+): Promise<PostAndMorePosts> => {
   const [post, more_posts] = await Promise.all([
-    client().getEntries<BlogPost>({
+    client(isPreview).getEntries<BlogPost>({
       content_type: "pageBlogPost",
       "fields.slug": slug,
       limit: 1,
     }),
-    client().getEntries<BlogPost>({
+    client(isPreview).getEntries<BlogPost>({
       content_type: "pageBlogPost",
       "fields.slug[nin]": [slug],
     }),
@@ -82,8 +84,8 @@ export const get_post_and_more_posts = async (slug: string): Promise<PostAndMore
   };
 };
 
-export const get_posts = async (): Promise<Post[]> => {
-  const { items } = await client().getEntries<BlogPost>({ content_type: "pageBlogPost" });
+export const get_posts = async (isPreview = false): Promise<Post[]> => {
+  const { items } = await client(isPreview).getEntries<BlogPost>({ content_type: "pageBlogPost" });
   return items.map(model_post);
 };
 

--- a/examples/contentful/src/routes/+layout.ts
+++ b/examples/contentful/src/routes/+layout.ts
@@ -1,7 +1,10 @@
-import { setPreview } from "sveltekit-preview-mode";
 import type { LayoutLoad } from "./$types";
 
 /**
  * Call `setPreview` with the `isPreview` value so that the `isPreview` value can be referenced in client-side code.
  */
-export const load = (({ data: { isPreview } }) => setPreview(isPreview)) satisfies LayoutLoad;
+export const load = (({ data: { isPreview } }) => {
+  return {
+    isPreview,
+  };
+}) satisfies LayoutLoad;

--- a/examples/contentful/src/routes/+page.server.ts
+++ b/examples/contentful/src/routes/+page.server.ts
@@ -1,8 +1,8 @@
 import cms from "$lib/cms";
 import type { PageServerLoad } from "./$types";
 
-export const load = (async () => {
+export const load = (async ({ locals }) => {
   return {
-    posts: await cms.get_posts(),
+    posts: await cms.get_posts(locals.isPreview),
   };
 }) satisfies PageServerLoad;

--- a/examples/contentful/src/routes/posts/[slug]/+page.server.ts
+++ b/examples/contentful/src/routes/posts/[slug]/+page.server.ts
@@ -1,6 +1,6 @@
 import cms from "$lib/cms";
 import type { PageServerLoad } from "./$types";
 
-export const load = (async ({ params }) => {
-  return await cms.get_post_and_more_posts(params.slug);
+export const load = (async ({ params, locals }) => {
+  return await cms.get_post_and_more_posts(params.slug, locals.isPreview);
 }) satisfies PageServerLoad;

--- a/examples/hygraph/src/routes/+layout.ts
+++ b/examples/hygraph/src/routes/+layout.ts
@@ -1,9 +1,10 @@
-import { setPreview } from "sveltekit-preview-mode";
 import type { LayoutLoad } from "./$types";
 
 /**
  * Call `setPreview` with the `isPreview` value so that the `isPreview` value can be referenced in client-side code.
  */
 export const load = (({ data: { isPreview } }) => {
-  setPreview(isPreview);
+  return {
+    isPreview,
+  };
 }) satisfies LayoutLoad;

--- a/examples/hygraph/src/routes/+page.server.ts
+++ b/examples/hygraph/src/routes/+page.server.ts
@@ -1,8 +1,8 @@
 import cms from "$lib/cms";
 import type { PageServerLoad } from "./$types";
 
-export const load = (async () => {
+export const load = (async ({ locals }) => {
   return {
-    posts: await cms.get_posts(),
+    posts: await cms.get_posts(locals.isPreview),
   };
 }) satisfies PageServerLoad;

--- a/examples/hygraph/src/routes/posts/[slug]/+page.server.ts
+++ b/examples/hygraph/src/routes/posts/[slug]/+page.server.ts
@@ -1,6 +1,6 @@
 import cms from "$lib/cms";
 import type { PageServerLoad } from "./$types";
 
-export const load = (async ({ params }) => {
-  return await cms.get_post_and_more_posts(params.slug);
+export const load = (async ({ params, locals }) => {
+  return await cms.get_post_and_more_posts(params.slug, locals.isPreview);
 }) satisfies PageServerLoad;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "prettier-plugin-svelte": "^3.0.3",
     "turbo": "^1.10.13"
   },
-  "packageManager": "pnpm@7.15.0",
+  "packageManager": "pnpm@8.10.5",
   "license": "ICS"
 }

--- a/packages/sveltekit-preview-mode/src/lib/components/PreviewBanner.svelte
+++ b/packages/sveltekit-preview-mode/src/lib/components/PreviewBanner.svelte
@@ -1,18 +1,17 @@
 <script lang="ts">
   import { page } from "$app/stores";
-  import { isPreview } from "../";
 
   let exit_link: string;
 
-	$: {
-		const url = new URL($page.url);
-		url.searchParams.set($page.data.exitPreviewQueryParam, 'true');
-		exit_link = url.toString();
-	}
+  $: {
+    const url = new URL($page.url);
+    url.searchParams.set($page.data.exitPreviewQueryParam, "true");
+    exit_link = url.toString();
+  }
 </script>
 
-{#if isPreview()}
-  <div class="preview-banner" role="dialog">
+{#if $page.data?.isPreview}
+  <div role="dialog" aria-modal="false" class="preview-banner">
     This page is a preview.
     <a rel="external" href={exit_link}>Click here</a>
     to exit preview mode.


### PR DESCRIPTION
## Description

Current preview mode implementation works by sharing `isPreview` store on the server and the client, Sveltekit docs explain some of the [issues this can cause](https://kit.svelte.dev/docs/state-management#avoid-shared-state-on-the-server) . Also more explanation in the original issue #14 

## Fix
`isPreview` is now scoped to the individual request by passing it down through `locals.isPreview` instead of storing it in a global store that is shared on the server. This is a breaking change as now any code using the store will not work, and have to be updated.
 
### Other fixes
Added a `building` check to the hook so that prerendering can be supported, also added section to readme to outline how prerendering can be supported. 

## Summary of fixes
- Removed `isPreview()` and preview store
- Updated all example code to new pattern
- Updated `PreviewBanner` to check page store instead of isPreview store. 
- Added Building Check to hook
- Updated pnpm
- Updated Readme

## Considerations 
- The example code that didn't take this pattern into account originally is bit messier now since we constantly have to pass in `isPreview` I tried to avoid changing the original style. I usually do this pattern cleaner using classes so we can reuse the client and preview mode can be stored. 

``` js
const client = new CmsClient(isPreview)

await client.getPosts(slug)
```

Let me know what you prefer. 


- Also I did not have access to the env variables for the CMS so I was unable to accurately test the examples. I however, tested on my setup and it works. 